### PR TITLE
Rename getBalance.ts to eth/getBalance.ts

### DIFF
--- a/client/src/tests.ts
+++ b/client/src/tests.ts
@@ -17,14 +17,14 @@ export async function run(
         ui: "bdd",
         timeout: 10 * 60 * 1000,
     });
-    await import("./tests/getBlockByHash");
-    await import("./tests/getBlockByNumber");
-    await import("./tests/getBlockTransactionCountByHash");
-    await import("./tests/getBlockTransactionCountByNumber");
-    await import("./tests/chainId");
-    await import("./tests/blockNumber");
-    await import("./tests/getBalance");
-    await import("./tests/getTransactionByHash");
+    await import("./tests/eth/getBlockByHash");
+    await import("./tests/eth/getBlockByNumber");
+    await import("./tests/eth/getBlockTransactionCountByHash");
+    await import("./tests/eth/getBlockTransactionCountByNumber");
+    await import("./tests/eth/chainId");
+    await import("./tests/eth/blockNumber");
+    await import("./tests/eth/getBalance");
+    await import("./tests/eth/getTransactionByHash");
 
     mocha.run();
 }

--- a/client/src/tests/eth/blockNumber.ts
+++ b/client/src/tests/eth/blockNumber.ts
@@ -1,4 +1,4 @@
-import { blockchain, wallet } from "../tests";
+import { blockchain, wallet } from "../../tests";
 import assert from "assert";
 
 describe("blockNumber", () => {

--- a/client/src/tests/eth/chainId.ts
+++ b/client/src/tests/eth/chainId.ts
@@ -1,4 +1,4 @@
-import { blockchain, wallet } from "../tests";
+import { blockchain, wallet } from "../../tests";
 import assert from "assert";
 
 describe("chainId", () => {

--- a/client/src/tests/eth/getBalance.ts
+++ b/client/src/tests/eth/getBalance.ts
@@ -1,4 +1,4 @@
-import { blockchain, wallet } from "../tests";
+import { blockchain, wallet } from "../../tests";
 import assert from "assert";
 
 describe("getBalance", () => {

--- a/client/src/tests/eth/getBlockByHash.ts
+++ b/client/src/tests/eth/getBlockByHash.ts
@@ -1,7 +1,7 @@
-import { blockchain, wallet } from "../tests";
+import { blockchain, wallet } from "../../tests";
 import assert from "assert";
 
-describe("getBlockByNumber", () => {
+describe("getBlockByHash", () => {
     it("returns the mined block", async () => {
         if (!blockchain || !wallet) {
             throw "not ready";
@@ -21,12 +21,17 @@ describe("getBlockByNumber", () => {
         await blockchain.send("evm_mine", [{ blocks: 1 }]);
         await response.wait(1);
 
-        const walletBlockByNumber = await wallet.getBlock(blockNumber + 1);
-        if (!walletBlockByNumber) {
+        const blockHash = (await blockchain.getBlock(blockNumber + 1))?.hash;
+        if (!blockHash) {
+            throw "no block hash";
+        }
+
+        const walletBlockByHash = await wallet.getBlock(blockHash);
+        if (!walletBlockByHash) {
             throw "no block";
         }
 
-        assert.equal(walletBlockByNumber.transactions[0], response.hash);
+        assert.equal(walletBlockByHash.transactions[0], response.hash);
     });
 
     it("behaves well when the block doesn't exist", async () => {
@@ -34,11 +39,11 @@ describe("getBlockByNumber", () => {
             throw "not ready";
         }
 
-        const blockNumber =
-            "0x0000000000000f00000000000000000000000000000000000000000000000000";
+        const blockHash =
+            "0x0000000000000000000000000000000000000000000000000000000000000000";
 
-        const walletBlockByNumber = await wallet.getBlock(blockNumber);
+        const walletBlockByHash = await wallet.getBlock(blockHash);
 
-        assert.equal(walletBlockByNumber, null);
+        assert.equal(walletBlockByHash, null);
     });
 });

--- a/client/src/tests/eth/getBlockByNumber.ts
+++ b/client/src/tests/eth/getBlockByNumber.ts
@@ -1,7 +1,7 @@
-import { blockchain, wallet } from "../tests";
+import { blockchain, wallet } from "../../tests";
 import assert from "assert";
 
-describe("getBlockByHash", () => {
+describe("getBlockByNumber", () => {
     it("returns the mined block", async () => {
         if (!blockchain || !wallet) {
             throw "not ready";
@@ -21,17 +21,12 @@ describe("getBlockByHash", () => {
         await blockchain.send("evm_mine", [{ blocks: 1 }]);
         await response.wait(1);
 
-        const blockHash = (await blockchain.getBlock(blockNumber + 1))?.hash;
-        if (!blockHash) {
-            throw "no block hash";
-        }
-
-        const walletBlockByHash = await wallet.getBlock(blockHash);
-        if (!walletBlockByHash) {
+        const walletBlockByNumber = await wallet.getBlock(blockNumber + 1);
+        if (!walletBlockByNumber) {
             throw "no block";
         }
 
-        assert.equal(walletBlockByHash.transactions[0], response.hash);
+        assert.equal(walletBlockByNumber.transactions[0], response.hash);
     });
 
     it("behaves well when the block doesn't exist", async () => {
@@ -39,11 +34,11 @@ describe("getBlockByHash", () => {
             throw "not ready";
         }
 
-        const blockHash =
-            "0x0000000000000000000000000000000000000000000000000000000000000000";
+        const blockNumber =
+            "0x0000000000000f00000000000000000000000000000000000000000000000000";
 
-        const walletBlockByHash = await wallet.getBlock(blockHash);
+        const walletBlockByNumber = await wallet.getBlock(blockNumber);
 
-        assert.equal(walletBlockByHash, null);
+        assert.equal(walletBlockByNumber, null);
     });
 });

--- a/client/src/tests/eth/getBlockTransactionCountByNumber.ts
+++ b/client/src/tests/eth/getBlockTransactionCountByNumber.ts
@@ -1,7 +1,7 @@
-import { blockchain, wallet } from "../tests";
+import { blockchain, wallet } from "../../tests";
 import assert from "assert";
 
-describe("getBlockTransactionCountByHash", () => {
+describe("getBlockTransactionCountByNumber", () => {
     it("returns zero for empty block", async () => {
         if (!blockchain || !wallet) {
             throw "not ready";
@@ -11,14 +11,10 @@ describe("getBlockTransactionCountByHash", () => {
 
         await blockchain.send("evm_mine", [{ blocks: 1 }]);
 
-        const blockHash = (await blockchain.getBlock(blockNumber + 1))?.hash;
-        if (!blockHash) {
-            throw "no block hash";
-        }
-
-        const count = await wallet.send("eth_getBlockTransactionCountByHash", [
-            blockHash,
-        ]);
+        const count = await wallet.send(
+            "eth_getBlockTransactionCountByNumber",
+            [blockNumber + 1]
+        );
         if (!count) {
             throw "no block";
         }
@@ -59,34 +55,28 @@ describe("getBlockTransactionCountByHash", () => {
         await blockchain.send("evm_mine", [{ blocks: 1 }]);
         const mined = await response.wait(1);
 
-        const blockHash0 = (await blockchain.getBlock(blockNumber + 1))?.hash;
-        if (!blockHash0) {
-            throw "no block hash";
-        }
-
-        const blockHash1 = (await blockchain.getBlock(blockNumber + 2))?.hash;
-        if (!blockHash1) {
-            throw "no block hash";
-        }
-
         assert.equal(
-            mined?.blockHash,
-            blockHash1,
-            `transaction block (${mined?.blockHash}) matches mined block (${blockHash1})`
+            mined?.blockNumber,
+            blockNumber + 2,
+            `transaction block (${mined?.blockNumber}) matches mined block (${
+                blockNumber + 2
+            })`
         );
 
-        const count0 = await wallet.send("eth_getBlockTransactionCountByHash", [
-            blockHash0,
-        ]);
+        const count0 = await wallet.send(
+            "eth_getBlockTransactionCountByNumber",
+            [blockNumber + 1]
+        );
         if (!count0) {
             throw "no block";
         }
 
         assert.equal(parseInt(count0, 16), 1);
 
-        const count1 = await wallet.send("eth_getBlockTransactionCountByHash", [
-            blockHash1,
-        ]);
+        const count1 = await wallet.send(
+            "eth_getBlockTransactionCountByNumber",
+            [blockNumber + 2]
+        );
         if (!count1) {
             throw "no block";
         }
@@ -98,9 +88,12 @@ describe("getBlockTransactionCountByHash", () => {
             throw "not ready";
         }
 
-        const count = await wallet.send("eth_getBlockTransactionCountByHash", [
-            "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-        ]);
+        const count = await wallet.send(
+            "eth_getBlockTransactionCountByNumber",
+            [
+                "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            ]
+        );
 
         assert.equal(count, null);
     });

--- a/client/src/tests/eth/getTransactionByHash.ts
+++ b/client/src/tests/eth/getTransactionByHash.ts
@@ -1,4 +1,4 @@
-import { blockchain, wallet } from "../tests";
+import { blockchain, wallet } from "../../tests";
 import assert from "assert";
 
 describe("getTransctionByHash", () => {


### PR DESCRIPTION
## Rationale

To avoid potential collisions, I recommend that file names of tests be equal to RPC endpoint names.